### PR TITLE
Rewrite bot in Python with discord.py and yt-dlp

### DIFF
--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -6,14 +6,15 @@ LABEL fly_launch_runtime="Python"
 
 WORKDIR /app
 
-# Install ffmpeg for audio processing
+# Install uv and ffmpeg
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y ffmpeg && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
-# Install Python dependencies
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+# Install dependencies with uv
+COPY pyproject.toml .
+RUN uv pip install --system -e .
 
 # Copy application code
 COPY bot.py .

--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -14,7 +14,7 @@ RUN apt-get update -qq && \
 
 # Install dependencies with uv
 COPY pyproject.toml .
-RUN uv pip install --system -e .
+RUN uv pip install --system .
 
 # Copy application code
 COPY bot.py .

--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -1,52 +1,23 @@
 # syntax = docker/dockerfile:1
 
-# Adjust NODE_VERSION as desired
-ARG NODE_VERSION=21.7.1
-FROM node:${NODE_VERSION}-slim as base
+FROM python:3.12-slim
 
-LABEL fly_launch_runtime="Node.js"
+LABEL fly_launch_runtime="Python"
 
-# Node.js app lives here
 WORKDIR /app
 
-# Set production environment
-ENV NODE_ENV="production"
-
-
-# Throw-away build stage to reduce size of final image
-FROM base as build
-
-# Install packages needed to build node modules
-RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
-
-# Install node modules
-COPY --link package-lock.json package.json ./
-RUN npm ci --include=dev
-
-# COPY package_overrides/sig.js node_modules/@distube/ytdl-core/lib/sig.js
-
-# Copy application code
-COPY --link . .
-
-# Build application
-RUN npm run build
-
-# Remove development dependencies
-RUN npm prune --omit=dev
-
-
-# Final stage for app image
-FROM base
-
-# Install packages needed for deployment
+# Install ffmpeg for audio processing
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y ffmpeg && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
-# Copy built application
-COPY --from=build /app /app
+# Install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 
-# Start the server by default, this can be overwritten at runtime
-EXPOSE 3000
-CMD [ "npm", "run", "start" ]
+# Copy application code
+COPY bot.py .
+COPY cogs/ cogs/
+
+# Run the bot
+CMD ["python", "bot.py"]

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,38 @@
+import os
+import asyncio
+
+import discord
+from discord.ext import commands
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+class SampleBot(commands.Bot):
+    def __init__(self):
+        intents = discord.Intents.default()
+        intents.message_content = True
+        super().__init__(command_prefix="!", intents=intents)
+
+    async def setup_hook(self):
+        await self.load_extension("cogs.sample")
+        await self.tree.sync()
+        print(f"Synced slash commands for {self.user}")
+
+    async def on_ready(self):
+        print(f"Server is ready to start processing things.")
+        print(f"Logged in as {self.user} (ID: {self.user.id})")
+
+
+async def main():
+    token = os.getenv("DISCORD_BOT_TOKEN")
+    if not token:
+        raise ValueError("DISCORD_BOT_TOKEN environment variable is not set")
+
+    bot = SampleBot()
+    async with bot:
+        await bot.start(token)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/cogs/sample.py
+++ b/cogs/sample.py
@@ -1,11 +1,10 @@
-import os
 import tempfile
 from pathlib import Path
 
 import discord
+import yt_dlp
 from discord import app_commands
 from discord.ext import commands
-import yt_dlp
 
 
 class Sample(commands.Cog):
@@ -19,7 +18,7 @@ class Sample(commands.Cog):
 
         try:
             with tempfile.TemporaryDirectory() as tmpdir:
-                output_template = os.path.join(tmpdir, "%(title)s.%(ext)s")
+                output_template = str(Path(tmpdir) / "%(title)s.%(ext)s")
 
                 ydl_opts = {
                     "format": "bestaudio/best",
@@ -34,14 +33,6 @@ class Sample(commands.Cog):
                     "quiet": True,
                     "no_warnings": True,
                 }
-
-                # Add cookies if provided
-                cookie = os.getenv("YT_COOKIE")
-                if cookie:
-                    cookie_file = os.path.join(tmpdir, "cookies.txt")
-                    with open(cookie_file, "w") as f:
-                        f.write(cookie)
-                    ydl_opts["cookiefile"] = cookie_file
 
                 with yt_dlp.YoutubeDL(ydl_opts) as ydl:
                     info = ydl.extract_info(url, download=True)
@@ -75,7 +66,7 @@ class Sample(commands.Cog):
         except Exception as e:
             print(f"Error downloading sample: {e}")
             await interaction.followup.send(
-                f"There was an error while executing this command.\n```\n{str(e)}\n```"
+                f"There was an error while executing this command.\n```\n{e!s}\n```"
             )
 
 

--- a/cogs/sample.py
+++ b/cogs/sample.py
@@ -1,0 +1,83 @@
+import os
+import tempfile
+from pathlib import Path
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+import yt_dlp
+
+
+class Sample(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @app_commands.command(name="sample", description="Download an audio sample from a URL")
+    @app_commands.describe(url="URL to download audio from (YouTube, SoundCloud, etc.)")
+    async def sample(self, interaction: discord.Interaction, url: str):
+        await interaction.response.send_message("Attempting to download sample...")
+
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                output_template = os.path.join(tmpdir, "%(title)s.%(ext)s")
+
+                ydl_opts = {
+                    "format": "bestaudio/best",
+                    "outtmpl": output_template,
+                    "postprocessors": [
+                        {
+                            "key": "FFmpegExtractAudio",
+                            "preferredcodec": "mp3",
+                            "preferredquality": "192",
+                        }
+                    ],
+                    "quiet": True,
+                    "no_warnings": True,
+                }
+
+                # Add cookies if provided
+                cookie = os.getenv("YT_COOKIE")
+                if cookie:
+                    cookie_file = os.path.join(tmpdir, "cookies.txt")
+                    with open(cookie_file, "w") as f:
+                        f.write(cookie)
+                    ydl_opts["cookiefile"] = cookie_file
+
+                with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                    info = ydl.extract_info(url, download=True)
+                    title = info.get("title", "Unknown Title")
+                    uploader = info.get("uploader", "Unknown Creator")
+
+                # Find the downloaded mp3 file
+                mp3_files = list(Path(tmpdir).glob("*.mp3"))
+                if not mp3_files:
+                    raise Exception("No audio file was created")
+
+                audio_file = mp3_files[0]
+                filename = f"{title} - {uploader}.mp3"
+
+                # Check file size (Discord limit is 25MB for regular, 100MB for nitro)
+                file_size = audio_file.stat().st_size
+                if file_size > 25 * 1024 * 1024:
+                    await interaction.followup.send(
+                        f"File is too large to upload ({file_size / 1024 / 1024:.1f}MB). "
+                        "Discord limit is 25MB."
+                    )
+                    return
+
+                discord_file = discord.File(audio_file, filename=filename)
+                await interaction.followup.send(
+                    content=f"{interaction.user.mention} Your sample is ready!",
+                    file=discord_file,
+                )
+                print(f"Successfully downloaded sample: {filename}")
+
+        except Exception as e:
+            print(f"Error downloading sample: {e}")
+            await interaction.followup.send(
+                f"There was an error while executing this command.\n```\n{str(e)}\n```"
+            )
+
+
+async def setup(bot: commands.Bot):
+    await bot.add_cog(Sample(bot))

--- a/fly.toml
+++ b/fly.toml
@@ -7,14 +7,7 @@ app = 'discord-samplebot'
 primary_region = 'ewr'
 
 [build]
-
-[http_service]
-  internal_port = 3000
-  force_https = true
-  auto_stop_machines = false
-  auto_start_machines = false
-  min_machines_running = 0
-  processes = ['app']
+  dockerfile = "Dockerfile.fly"
 
 [[vm]]
   memory = '1gb'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ dev = [
     "ruff>=0.4.0",
 ]
 
+[tool.setuptools]
+packages = []
+
 [tool.ruff]
 target-version = "py312"
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[project]
+name = "discord-samplebot"
+version = "1.0.0"
+description = "Discord bot for downloading audio samples"
+requires-python = ">=3.12"
+dependencies = [
+    "discord-py>=2.3.0",
+    "python-dotenv>=1.0.0",
+    "yt-dlp>=2024.1.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "ruff>=0.4.0",
+]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+[tool.ruff.lint]
+select = [
+    "E",     # pycodestyle errors
+    "W",     # pycodestyle warnings
+    "F",     # pyflakes
+    "I",     # isort
+    "B",     # flake8-bugbear
+    "UP",    # pyupgrade
+]
+
+[tool.ruff.format]
+quote-style = "double"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-discord.py>=2.3.0
-python-dotenv>=1.0.0
-yt-dlp>=2024.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+discord.py>=2.3.0
+python-dotenv>=1.0.0
+yt-dlp>=2024.1.0


### PR DESCRIPTION
## Summary
- Replace Node.js/youtubei.js with Python/discord.py + yt-dlp for better reliability
- Support all yt-dlp sites (YouTube, SoundCloud, Bandcamp, Twitter, TikTok, etc.)
- Simplified deployment config

## Why
youtubei.js keeps breaking due to YouTube's constant signature changes. yt-dlp has a massive community actively patching these issues, making it far more reliable.

## Test plan
- [x] Run locally with `pip install -r requirements.txt && python bot.py`
- [x] Test `/sample` with a YouTube URL
- [ ] Test `/sample` with a non-YouTube URL (SoundCloud, etc.)
- [ ] Deploy to Fly.io and verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)